### PR TITLE
refactor: 예약번호 부여 방식 및 예약 상태 로직 수정

### DIFF
--- a/app/src/config/db/init/init.sql
+++ b/app/src/config/db/init/init.sql
@@ -71,7 +71,7 @@ CREATE TABLE schedule_slot (
   medical_schedule_id INTEGER NOT NULL,
   slot_date DATE NOT NULL,
   current_appointments INTEGER NOT NULL DEFAULT 0,
-  next_appointment_number INTEGER NOT NULL DEFAULT 0,
+  next_appointment_number INTEGER NOT NULL DEFAULT 1,
   FOREIGN KEY (medical_schedule_id) REFERENCES medical_schedule(id)
 );
 

--- a/app/src/config/db/init/init.sql
+++ b/app/src/config/db/init/init.sql
@@ -105,7 +105,7 @@ CREATE TABLE appointment (
   id INTEGER PRIMARY KEY AUTO_INCREMENT,
   user_id INTEGER NOT NULL,
   schedule_slot_id INTEGER NOT NULL,
-  appointment_number VARCHAR(20) NOT NULL,
+  appointment_number INTEGER NOT NULL,
   appointment_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
   notes TEXT,
   type VARCHAR(20) NOT NULL,

--- a/app/src/config/db/init/init.sql
+++ b/app/src/config/db/init/init.sql
@@ -72,7 +72,6 @@ CREATE TABLE schedule_slot (
   slot_date DATE NOT NULL,
   current_appointments INTEGER NOT NULL DEFAULT 0,
   next_appointment_number INTEGER NOT NULL DEFAULT 0,
-  current_completed_appointments INTEGER NOT NULL DEFAULT 0,
   FOREIGN KEY (medical_schedule_id) REFERENCES medical_schedule(id)
 );
 

--- a/app/src/config/db/migration-scripts/V3_UpdateScheduleSlot.sql
+++ b/app/src/config/db/migration-scripts/V3_UpdateScheduleSlot.sql
@@ -1,2 +1,5 @@
 ALTER TABLE schedule_slot
 DROP COLUMN current_completed_appointments;
+
+ALTER TABLE schedule_slot
+MODIFY next_appointment_number INTEGER NOT NULL DEFAULT 1;

--- a/app/src/config/db/migration-scripts/V3_UpdateScheduleSlot.sql
+++ b/app/src/config/db/migration-scripts/V3_UpdateScheduleSlot.sql
@@ -3,3 +3,6 @@ DROP COLUMN current_completed_appointments;
 
 ALTER TABLE schedule_slot
 MODIFY next_appointment_number INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE appointment 
+MODIFY COLUMN appointment_number INTEGER NOT NULL;

--- a/app/src/config/db/migration-scripts/V3_UpdateScheduleSlot.sql
+++ b/app/src/config/db/migration-scripts/V3_UpdateScheduleSlot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE schedule_slot
+DROP COLUMN current_completed_appointments;

--- a/app/src/middlewares/appointment-validation.js
+++ b/app/src/middlewares/appointment-validation.js
@@ -1,0 +1,17 @@
+"use strict"
+
+const { BadRequestError } = require("../utils/custom-error");
+
+const validStatuses = ['cancelled', 'completed', 'absent'];
+
+const validStatus = (req, res, next) => {
+    const { status } = req.body;
+    if (!validStatuses.includes(status)) {
+        throw new BadRequestError();
+    }
+    next();
+};
+
+module.exports = {
+    validStatus,
+}

--- a/app/src/models/slot-model.js
+++ b/app/src/models/slot-model.js
@@ -20,10 +20,6 @@ async function decrementAppointmentCount(scheduleSlotId, conn) {
     await conn.execute('UPDATE schedule_slot SET current_appointments = current_appointments - 1 WHERE id = ?', [scheduleSlotId]);
 }
 
-async function updateCompletedAppointments(scheduleSlotId, conn) {
-    await conn.execute('UPDATE schedule_slot SET current_completed_appointments = current_completed_appointments + 1 WHERE id = ?', [scheduleSlotId]);
-}
-
 async function selectScheduleByDoctorIdAndDate(doctorId, date) {
     const query = `
       SELECT 
@@ -51,5 +47,4 @@ module.exports = {
     incrementAppointmentCount,
     selectScheduleByDoctorIdAndDate,
     decrementAppointmentCount,
-    updateCompletedAppointments,
 };

--- a/app/src/routes/appointment-router.js
+++ b/app/src/routes/appointment-router.js
@@ -5,9 +5,10 @@ const router = express.Router();
 
 const ctrl = require('../controllers/appointment-controller');
 const auth = require('../middlewares/auth-middleware');
+const validator = require('../middlewares/appointment-validation');
 
 router.post("/", auth.isAuth, ctrl.makeAppointment);
 router.patch("/:appointmentId", auth.isAuth, ctrl.modifyAppointment);
-router.patch("/:appointmentId/status", auth.isAuth, ctrl.modifyAppointmentStatus);
+router.patch("/:appointmentId/status", auth.isAuth, validator.validStatus, ctrl.modifyAppointmentStatus);
 
 module.exports = router;

--- a/app/src/services/appointment-service.js
+++ b/app/src/services/appointment-service.js
@@ -78,12 +78,12 @@ function checkPermissionToModifyStatus(user, appointment, status) {
         throw new BadRequestError();
     }
     if (isUser) {
-        if (appointment.userId !== user.id || status !== "cancelled") { //본인이 아니거나 취소 이외로 변경하려는 경우
+        if (appointment.userId !== user.id || status !== "cancelled") { //본인이 아니거나 취소 이외로 변경하려는 경우 , cancelled만 가능
             throw new ForbiddenError();
         }
     }
-    else if (isHospitalMember) {
-        if (status === "confirmed" || status === "cancelled") {
+    else if (isHospitalMember) { //completed, absent 만 가능
+        if (status === "cancelled") {
             throw new ForbiddenError();
         }
     }

--- a/app/src/services/appointment-service.js
+++ b/app/src/services/appointment-service.js
@@ -39,8 +39,7 @@ async function createAppointment(userId, appointmentDTO) {
         await conn.beginTransaction();
         const slotInfo = await slotModel.findScheduleSlotWithMedicalScheduleById(appointmentDTO.scheduleSlotId, conn);
         if (slotInfo.currentAppointments < slotInfo.maxAppointments) {
-            const appointmentNumber = slotInfo.scheduleIdentifier + '-' + slotInfo.nextAppointmentNumber;
-            await appointmentModel.insertAppointment(userId, appointmentNumber, appointmentDTO, conn);
+            await appointmentModel.insertAppointment(userId, slotInfo.nextAppointmentNumber, appointmentDTO, conn);
             await slotModel.incrementAppointmentCount(appointmentDTO.scheduleSlotId, conn);
             await conn.commit();
             return true;

--- a/app/src/services/appointment-service.js
+++ b/app/src/services/appointment-service.js
@@ -102,8 +102,6 @@ async function modifyAppointmentStatus(user, appointmentId, status) {
         await appointmentModel.updateAppointmentStatus(appointmentId, status, conn);
         if (status === "cancelled") {
             await slotModel.decrementAppointmentCount(appointment.scheduleSlotId, conn);
-        } else if (status === "completed" || status === "absent") {
-            await slotModel.updateCompletedAppointments(appointment.scheduleSlotId, conn);
         }
         await conn.commit();
     } catch (error) {


### PR DESCRIPTION
## Overview
- 기존에 데이터베이스에 예약번호를 A-0, B-1 처럼 문자열을 저장 했는데 이를 숫자만 저장하는 방식으로 수정함
- 또한 current_completed_appointments 컬럼은 무결성을 해치므로 appointment테이블에서 쿼리로 대체할 수 있어 해당 컬럼을 삭제함
- 예약 상태 수정시 status값의 유효성 검증부분을 추가함

## Change Log
- init.sql 수정
- V3_UpdateScheduleSlot.sql  추가
- appointment-validation.js 추가
- slot-model.js 수정
- appointment-router 수정
- appointment-service 수정

## Issue Tags
- Closed: #26 