### PR TITLE
refactor: schedule_slot 테이블 컬럼 수정

### DIFF
--- a/app/src/config/db/init/init.sql
+++ b/app/src/config/db/init/init.sql
@@ -70,8 +70,6 @@ CREATE TABLE schedule_slot (
   id INTEGER PRIMARY KEY AUTO_INCREMENT,
   medical_schedule_id INTEGER NOT NULL,
   slot_date DATE NOT NULL,
-  current_appointments INTEGER NOT NULL DEFAULT 0,
-  next_appointment_number INTEGER NOT NULL DEFAULT 1,
   FOREIGN KEY (medical_schedule_id) REFERENCES medical_schedule(id)
 );
 

--- a/app/src/config/db/init/init.sql
+++ b/app/src/config/db/init/init.sql
@@ -60,7 +60,7 @@ CREATE TABLE medical_schedule (
   day_of_week VARCHAR(20) NOT NULL,
   start_time TIME NOT NULL,
   end_time TIME NOT NULL,
-  max_appointments INTEGER NOT NULL,
+  initial_max_appointments INTEGER NOT NULL,
   schedule_identifier CHAR(1) NOT NULL,
   FOREIGN KEY (doctor_id) REFERENCES doctor(id)
 );
@@ -70,6 +70,7 @@ CREATE TABLE schedule_slot (
   id INTEGER PRIMARY KEY AUTO_INCREMENT,
   medical_schedule_id INTEGER NOT NULL,
   slot_date DATE NOT NULL,
+  slot_max_appointments INTEGER NOT NULL,
   FOREIGN KEY (medical_schedule_id) REFERENCES medical_schedule(id)
 );
 

--- a/app/src/config/db/migration-scripts/V4_DeleteScheduleSlotColumn.sql
+++ b/app/src/config/db/migration-scripts/V4_DeleteScheduleSlotColumn.sql
@@ -3,3 +3,9 @@ DROP COLUMN current_appointments;
 
 ALTER TABLE schedule_slot
 DROP COLUMN next_appointment_number;
+
+ALTER TABLE medical_schedule
+CHANGE COLUMN max_appointments initial_max_appointments INTEGER NOT NULL;
+
+ALTER TABLE schedule_slot
+ADD COLUMN slot_max_appointments INTEGER NOT NULL;

--- a/app/src/config/db/migration-scripts/V4_DeleteScheduleSlotColumn.sql
+++ b/app/src/config/db/migration-scripts/V4_DeleteScheduleSlotColumn.sql
@@ -1,0 +1,5 @@
+ALTER TABLE schedule_slot
+DROP COLUMN current_appointments;
+
+ALTER TABLE schedule_slot
+DROP COLUMN next_appointment_number;

--- a/app/src/models/appointment-model.js
+++ b/app/src/models/appointment-model.js
@@ -29,9 +29,24 @@ async function updateAppointment(appointmentId, updateData) {
     await pool.execute(sql, [...values, appointmentId]);
 }
 
-async function updateAppointmentStatus(appointmentId, status, conn) {
+async function updateAppointmentStatus(appointmentId, status) {
     const sql = 'UPDATE appointment SET status = ? WHERE id = ?';
-    await conn.execute(sql, [status, appointmentId]);
+    await pool.execute(sql, [status, appointmentId]);
+}
+
+async function countConfirmedAppointmentsBySlotId(scheduleSlotId, conn, forUpdate = false) {
+    let query = `SELECT COUNT(*) AS count FROM appointment WHERE schedule_slot_id = ? AND status = 'confirmed'`;
+    if (forUpdate) {
+        query += ' FOR UPDATE';
+    }
+    const [rows] = await conn.execute(query, [scheduleSlotId]);
+    return rows[0].count;
+}
+
+async function getNextAppointmentNumber(scheduleSlotId, conn) {
+    const query = `SELECT MAX(appointment_number) AS maxAppointmentNumber FROM appointment WHERE schedule_slot_id = ?`;
+    const [rows] = await conn.execute(query, [scheduleSlotId]);
+    return rows[0].maxAppointmentNumber !== null ? rows[0].maxAppointmentNumber + 1 : 1;
 }
 
 module.exports = {
@@ -40,4 +55,6 @@ module.exports = {
     insertAppointment,
     updateAppointment,
     updateAppointmentStatus,
+    countConfirmedAppointmentsBySlotId,
+    getNextAppointmentNumber,
 };

--- a/app/src/models/appointment-model.js
+++ b/app/src/models/appointment-model.js
@@ -34,12 +34,12 @@ async function updateAppointmentStatus(appointmentId, status) {
     await pool.execute(sql, [status, appointmentId]);
 }
 
-async function countConfirmedAppointmentsBySlotId(scheduleSlotId, conn, forUpdate = false) {
+async function countConfirmedAppointmentsBySlotId(scheduleSlotId, conn = null, forUpdate = false) {
     let query = `SELECT COUNT(*) AS count FROM appointment WHERE schedule_slot_id = ? AND status = 'confirmed'`;
     if (forUpdate) {
         query += ' FOR UPDATE';
     }
-    const [rows] = await conn.execute(query, [scheduleSlotId]);
+    const [rows] = await (conn || pool).execute(query, [scheduleSlotId]);
     return rows[0].count;
 }
 

--- a/app/src/models/slot-model.js
+++ b/app/src/models/slot-model.js
@@ -4,10 +4,7 @@ const { convertToCamelCase } = require('../utils/util');
 const pool = require('../config/db/mysql');
 
 async function findScheduleSlotWithMedicalScheduleById(scheduleSlotId, conn = null) {
-    let query = `SELECT * FROM schedule_slot INNER JOIN medical_schedule ON schedule_slot.medical_schedule_id = medical_schedule.id WHERE schedule_slot.id = ?`;
-    if (conn) {
-        query += ' FOR UPDATE';
-    }
+    const query = `SELECT * FROM schedule_slot INNER JOIN medical_schedule ON schedule_slot.medical_schedule_id = medical_schedule.id WHERE schedule_slot.id = ?`;
     const [rows] = await (conn || pool).execute(query, [scheduleSlotId]);
     return rows.length > 0 ? convertToCamelCase(rows[0]) : null;
 }

--- a/app/src/models/slot-model.js
+++ b/app/src/models/slot-model.js
@@ -12,10 +12,6 @@ async function findScheduleSlotWithMedicalScheduleById(scheduleSlotId, conn = nu
     return rows.length > 0 ? convertToCamelCase(rows[0]) : null;
 }
 
-async function incrementAppointmentCount(scheduleSlotId, conn) {
-    await conn.execute('UPDATE schedule_slot SET current_appointments = current_appointments + 1, next_appointment_number = next_appointment_number + 1 WHERE id = ?', [scheduleSlotId]);
-}
-
 async function selectScheduleByDoctorIdAndDate(doctorId, date) {
     const query = `
       SELECT 
@@ -40,6 +36,5 @@ async function selectScheduleByDoctorIdAndDate(doctorId, date) {
 
 module.exports = {
     findScheduleSlotWithMedicalScheduleById,
-    incrementAppointmentCount,
     selectScheduleByDoctorIdAndDate,
 };

--- a/app/src/models/slot-model.js
+++ b/app/src/models/slot-model.js
@@ -16,10 +16,6 @@ async function incrementAppointmentCount(scheduleSlotId, conn) {
     await conn.execute('UPDATE schedule_slot SET current_appointments = current_appointments + 1, next_appointment_number = next_appointment_number + 1 WHERE id = ?', [scheduleSlotId]);
 }
 
-async function decrementAppointmentCount(scheduleSlotId, conn) {
-    await conn.execute('UPDATE schedule_slot SET current_appointments = current_appointments - 1 WHERE id = ?', [scheduleSlotId]);
-}
-
 async function selectScheduleByDoctorIdAndDate(doctorId, date) {
     const query = `
       SELECT 
@@ -46,5 +42,4 @@ module.exports = {
     findScheduleSlotWithMedicalScheduleById,
     incrementAppointmentCount,
     selectScheduleByDoctorIdAndDate,
-    decrementAppointmentCount,
 };

--- a/app/src/models/slot-model.js
+++ b/app/src/models/slot-model.js
@@ -24,8 +24,7 @@ async function selectScheduleByDoctorIdAndDate(doctorId, date) {
       schedule_slot.slot_date,
       medical_schedule.start_time,
       medical_schedule.end_time,
-      medical_schedule.max_appointments,
-      schedule_slot.current_appointments
+      schedule_slot.slot_max_appointments
       FROM medical_schedule
       JOIN schedule_slot ON medical_schedule.id = schedule_slot.medical_schedule_id
       WHERE medical_schedule.doctor_id = ?

--- a/app/src/models/slot-model.js
+++ b/app/src/models/slot-model.js
@@ -9,6 +9,12 @@ async function findScheduleSlotWithMedicalScheduleById(scheduleSlotId, conn = nu
     return rows.length > 0 ? convertToCamelCase(rows[0]) : null;
 }
 
+async function findSlotMaxAppointments(scheduleSlotId, conn = null) {
+    const query = `SELECT slot_max_appointments FROM schedule_slot WHERE schedule_slot.id = ?`;
+    const [rows] = await (conn || pool).execute(query, [scheduleSlotId]);
+    return convertToCamelCase(rows[0]);
+}
+
 async function selectScheduleByDoctorIdAndDate(doctorId, date) {
     const query = `
       SELECT 
@@ -33,5 +39,6 @@ async function selectScheduleByDoctorIdAndDate(doctorId, date) {
 
 module.exports = {
     findScheduleSlotWithMedicalScheduleById,
+    findSlotMaxAppointments,
     selectScheduleByDoctorIdAndDate,
 };

--- a/app/src/services/appointment-service.js
+++ b/app/src/services/appointment-service.js
@@ -37,9 +37,9 @@ async function createAppointment(userId, appointmentDTO) {
     const conn = await pool.getConnection();
     try {
         await conn.beginTransaction();
-        const slotInfo = await slotModel.findScheduleSlotWithMedicalScheduleById(appointmentDTO.scheduleSlotId, conn);
+        const { slotMaxAppointments } = await slotModel.findSlotMaxAppointments(appointmentDTO.scheduleSlotId, conn);
         const currentAppointments = await appointmentModel.countConfirmedAppointmentsBySlotId(appointmentDTO.scheduleSlotId, conn, true);
-        if (currentAppointments < slotInfo.maxAppointments) {
+        if (currentAppointments < slotMaxAppointments) {
             const appointmentNumber = await appointmentModel.getNextAppointmentNumber(appointmentDTO.scheduleSlotId, conn);
             await appointmentModel.insertAppointment(userId, appointmentNumber, appointmentDTO, conn);
             await conn.commit();

--- a/app/src/services/appointment-service.js
+++ b/app/src/services/appointment-service.js
@@ -94,21 +94,7 @@ async function modifyAppointmentStatus(user, appointmentId, status) {
         throw new NotFoundError();
     }
     checkPermissionToModifyStatus(user, appointment, status);
-
-    const conn = await pool.getConnection();
-    try {
-        await conn.beginTransaction();
-        await appointmentModel.updateAppointmentStatus(appointmentId, status, conn);
-        if (status === "cancelled") {
-            await slotModel.decrementAppointmentCount(appointment.scheduleSlotId, conn);
-        }
-        await conn.commit();
-    } catch (error) {
-        await conn.rollback();
-        throw error;
-    } finally {
-        conn.release();
-    }
+    await appointmentModel.updateAppointmentStatus(appointmentId, status, conn);
 }
 
 module.exports = {

--- a/app/src/services/appointment-service.js
+++ b/app/src/services/appointment-service.js
@@ -40,7 +40,6 @@ async function createAppointment(userId, appointmentDTO) {
         const slotInfo = await slotModel.findScheduleSlotWithMedicalScheduleById(appointmentDTO.scheduleSlotId, conn);
         if (slotInfo.currentAppointments < slotInfo.maxAppointments) {
             await appointmentModel.insertAppointment(userId, slotInfo.nextAppointmentNumber, appointmentDTO, conn);
-            await slotModel.incrementAppointmentCount(appointmentDTO.scheduleSlotId, conn);
             await conn.commit();
             return true;
         } else {

--- a/app/src/services/doctor-service.js
+++ b/app/src/services/doctor-service.js
@@ -1,15 +1,16 @@
 "user strict"
 
 const slotModel = require('../models/slot-model');
+const appointmentModel = require('../models/appointment-model');
 
 async function findSlotsByDate(doctorId, date) {
     let result = await slotModel.selectScheduleByDoctorIdAndDate(doctorId, date);
-    result = result.map(row => {
+    for (let row of result) {
         row.startTime = row.startTime.slice(0, 5);
         row.endTime = row.endTime.slice(0, 5);
         row.slotDate = row.slotDate.toISOString().split('T')[0];
-        return row;
-    });    
+        row.currentAppointments = await appointmentModel.countConfirmedAppointmentsBySlotId(row.scheduleSlotId);
+    }
     return result;
 }
 


### PR DESCRIPTION
## Overview
- schedule_slot 테이블의 current_appointments와 next_appointment_number 컬럼을 삭제함
- 삭제 후 특정 슬롯에대한 현재 예약수를 확인하는 쿼리와 그 슬롯에 다음 예약번호를 가져오는 쿼리를 추가함
- 이로써 데이터의 무결성 문제를 해결하고 예약 추가,수정시 이 필드들을 업데이트하는 일이 없어 복잡성이 저하됨

## Change Log
- init.sql 수정
- V4_DeleteScheduleSlotColumn.sql 수정
- appointment-model.js 수정
- slot-model.js 수정
- appointment-service.js 수정

## To Reviewer
- V4 마이그레이션 파일을 실행해주시기 바랍니다.

## Issue Tags
- Closed: #29