### PR TITLE
feat: 사용자의 예약 조회 기능 구현

### DIFF
--- a/app/src/controllers/user-controller.js
+++ b/app/src/controllers/user-controller.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const userService = require('../services/user-service');
+const appointmentService = require('../services/appointment-service');
 const { ForbiddenError }= require('../utils/custom-error');
 const { OK, CREATED } = require('../constants/httpStatusCodes');
 
@@ -51,9 +52,23 @@ const login = async (req, res) => {
     });
 }
 
+const getUserAppointments = async (req, res) => {
+    const { status } = req.query;
+    const userId = req.params.userId;
+    if (String(req.user.id) !== userId) {
+        throw new ForbiddenError();
+    }
+    const result = await appointmentService.getAppointmentsByUser(userId, status);
+    res.status(OK).json({
+        message: "예약조회를 성공하였습니다.",
+        data: result
+    })
+}
+
 module.exports = {
     checkEmailDuplication,
     register,
     modifyUser,
     login,
+    getUserAppointments,
 };

--- a/app/src/routes/user-router.js
+++ b/app/src/routes/user-router.js
@@ -8,6 +8,7 @@ const validation = require('../middlewares/user-validation');
 const auth = require('../middlewares/auth-middleware');
 
 router.get("/emails", validation.emailRequest, ctrl.checkEmailDuplication);
+router.get("/:userId/appointments", auth.isAuth, ctrl.getUserAppointments);
 router.post("/", validation.signupRequest, ctrl.register);
 router.patch("/:userId", auth.isAuth, validation.modifyRequest, ctrl.modifyUser);
 router.post("/login", ctrl.login);

--- a/app/src/services/appointment-service.js
+++ b/app/src/services/appointment-service.js
@@ -128,7 +128,7 @@ async function getPastAppointments(userId) {
 }
 
 async function getWaitingCount(appointment) {
-    const waitingNumSameSlot = await appointmentModel.getWaitingNumSameSlot(appointment.scheduleSlotId, appointment.appointmentNumber); // 해당 예약과 같은 슬롯내의 대기인원
+    const waitingNumSameSlot = await appointmentModel.getWaitingNumSameSlot(appointment.scheduleSlotId, appointment.appointmentNumber); // 같은 예약 슬롯내의 자신보다 앞선 예약번호를 가진 대기인원
     const waitingNumPrevSlot = await appointmentModel.getWaitingNumPrevSlots(appointment.doctorId, appointment.slotDate, appointment.startTime); // 해당 예약과 같은 날짜의 예약 중 자신보다 앞쪽 슬롯의 대기인원
     return waitingNumPrevSlot + waitingNumSameSlot;
 }

--- a/app/src/services/doctor-service.js
+++ b/app/src/services/doctor-service.js
@@ -2,13 +2,14 @@
 
 const slotModel = require('../models/slot-model');
 const appointmentModel = require('../models/appointment-model');
+const { convertDateToISOString } = require('../utils/util');
 
 async function findSlotsByDate(doctorId, date) {
     let result = await slotModel.selectScheduleByDoctorIdAndDate(doctorId, date);
     for (let row of result) {
         row.startTime = row.startTime.slice(0, 5);
         row.endTime = row.endTime.slice(0, 5);
-        row.slotDate = row.slotDate.toISOString().split('T')[0];
+        row.slotDate = convertDateToISOString(row.slotDate)
         row.currentAppointments = await appointmentModel.countConfirmedAppointmentsBySlotId(row.scheduleSlotId);
     }
     return result;

--- a/app/src/utils/util.js
+++ b/app/src/utils/util.js
@@ -26,6 +26,10 @@ function convertToSnakeCase(input) {
     return newObj;
 }
 
+function convertDateToISOString(date) {
+    return date.toISOString().split('T')[0];
+}
+
 /**
  * 주어진 데이터 객체(data)에서 유효한 키(validKeys)에 해당하는 속성만을 추출하여 새로운 객체를 생성하는 함수.
  * 만약 data 객체가 유효하지 않은 키를 포함하고 있다면, 함수는 null을 반환
@@ -55,5 +59,6 @@ function filterValidKeys(data, validKeys) {
 module.exports = {
     convertToCamelCase,
     convertToSnakeCase,
+    convertDateToISOString,
     filterValidKeys,
 };


### PR DESCRIPTION
## Overview
- 사용자의 예약을 조회 하는 기능을 추가함
- status 값에 따라 과거 예약, 현재 예약을 구분해서 조회함
- 현재 예약일 경우 대기인원을 계산해 결과에 추가하였음
- 대기인원은 같은 예약 슬롯내의 자신보다 앞선 예약번호를 가진 대기인원과  해당 예약과 같은 날짜의 예약 중 자신보다 앞쪽 슬롯의 모든 대기인원으로 더하는 방식으로 계산함

## Change Log
- user-router.js 수정
- user-controller.js 수정
- appointment-service.js 수정
- appointment-model.js 수정

## To Reviewer
-  대기인원은 모든 현재 예약을 계산하는 걸로 코드를 작성했습니다. 예약 날짜와 시간대에 따라 대기 인원이 많아질 수도, 적어질 수도 있습니다. 이에 대한 피드백이 있으시다면 부탁드립니다. 
- 개인적으로는, 서버에서 특정 시간 전의 예약만 계산하는 것이 코드의 복잡성을 높일 수 있으므로, 서버에서는 모든 현재 예약을 계산하고, 프론트엔드에서 필요한 부분만 표시하는 방식을 제안하고 싶습니다.

## Issue Tags
- Closed: #25 